### PR TITLE
Sheep movement 2

### DIFF
--- a/Scenes/Grass/Grass.gd
+++ b/Scenes/Grass/Grass.gd
@@ -1,20 +1,27 @@
+tool
 extends Area2D
 
+const NORMAL_SPRITE_RECT = Vector2(512, 192)
+const VOLATILE_SPRITE_RECT = Vector2(192, 128)
 
+export var is_volatile = false setget set_is_volatile
 var being_eaten = false
 
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
+func update_sprite():
+	$Sprite.region_rect.position = VOLATILE_SPRITE_RECT if is_volatile else NORMAL_SPRITE_RECT
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass
+func set_is_volatile(value):
+	if is_volatile != value:
+		is_volatile = value
+		update_sprite()
 
 
 func _on_Grass_body_entered(body):
+	if Engine.editor_hint:
+		return
+	
 	if body.is_in_group("sheeps") and being_eaten == false and body.targeted_grass == self:
 		being_eaten = true
 		body.eat_grass()

--- a/Scenes/Sheep/Sheep.gd
+++ b/Scenes/Sheep/Sheep.gd
@@ -57,9 +57,10 @@ func calc_direction_to_nearest_grass():
 		return Vector2.ZERO
 
 
+# calculate direction to the shepherd (player), the shepherd.magnet_factor will cahnge depending iif the player is using the magnet or not
 func calc_direction_to_shepherd():
 	if shepherd:
-		return position.direction_to(shepherd.position) * shepherd_factor
+		return position.direction_to(shepherd.position) * shepherd_factor * shepherd.magnet_factor
 	else:
 		return Vector2.ZERO
 
@@ -89,10 +90,10 @@ func target_grass():
 
 
 func eat_grass():
-	# play animation
+	# play eating animation
 	# wait a certain amount of time
-	if targeted_grass.is_volatile():
-		pass # BOOM
+	if targeted_grass.is_volatile:
+		queue_free() # BOOM
 	else:
 		hunger -= 1
 	

--- a/Scenes/Sheep/Sheep.gd
+++ b/Scenes/Sheep/Sheep.gd
@@ -91,9 +91,13 @@ func target_grass():
 func eat_grass():
 	# play animation
 	# wait a certain amount of time
+	if targeted_grass.is_volatile():
+		pass # BOOM
+	else:
+		hunger -= 1
+	
 	targeted_grass.queue_free()
 	targeted_grass = null
-	hunger -= 1
 
 
 func _on_DetectionArea_body_entered(body):

--- a/Scenes/Shepherd/Shepherd.gd
+++ b/Scenes/Shepherd/Shepherd.gd
@@ -1,12 +1,18 @@
 extends KinematicBody2D
 
+# the magnet_factor to apply whent the magnet is on or off
+const MAGNET_OFF = 1
+const MAGNET_ON = 5
+
 export var ACCELERATION = 600
 export var MAX_SPEED = 125
 export var FRICTION = 600
 
 var velocity = Vector2.ZERO
+var magnet_factor = 1 # this factor will be multiplied in the sheep logic to decide if it should prioritize to follow the shepherd
 
 func _physics_process(delta):
+	magnet_factor = MAGNET_ON if Input.is_action_pressed("interact") else MAGNET_OFF
 	move_state(delta)
 	
 func move_state(delta):

--- a/Scenes/World/World.tscn
+++ b/Scenes/World/World.tscn
@@ -156,6 +156,23 @@ tile_data = PoolIntArray( -65523, 0, 0, -65520, 0, 0, 7, 2, 0, 10, 2, 0, 12, 3, 
 [node name="Grass2" parent="." instance=ExtResource( 5 )]
 position = Vector2( 146, 547 )
 
+[node name="Grass10" parent="." instance=ExtResource( 5 )]
+position = Vector2( 292, 353 )
+
+[node name="Grass11" parent="." instance=ExtResource( 5 )]
+position = Vector2( 388, 470 )
+
+[node name="Grass12" parent="." instance=ExtResource( 5 )]
+position = Vector2( 480, 286 )
+
+[node name="Grass13" parent="." instance=ExtResource( 5 )]
+position = Vector2( 965, 554 )
+is_volatile = true
+
+[node name="Grass14" parent="." instance=ExtResource( 5 )]
+position = Vector2( 913, 665 )
+is_volatile = true
+
 [node name="Grass4" parent="." instance=ExtResource( 5 )]
 position = Vector2( 108, 560 )
 


### PR DESCRIPTION
added volatile grass patch (exported var in grass patch which allow to set them volatile in editor)
sheeps will try to it them like regular path but will die if they do (currently just queue_free, will be updated with animation when availlable)
the shepherd can now use a magnet by keeping E pressed to force the sheeps to follow him

should solve tasks sheep exploding logic, electri/volatile grass patch and character attract sheep (magnet) input control